### PR TITLE
fix(geojsonparser): fix index check

### DIFF
--- a/src/scripts/lib/deck-gl/create-geojson-from-data.ts
+++ b/src/scripts/lib/deck-gl/create-geojson-from-data.ts
@@ -28,7 +28,7 @@ export default function createGeojsonFromData(
   const columns = data[0];
   const geometryIndex = columns.indexOf('geometry');
 
-  if (!geometryIndex) {
+  if (geometryIndex < 0) {
     return null;
   }
 


### PR DESCRIPTION
Fixing an error where data is not transformed into GeoJSON internally when gthe geometry column was the first column,