### PR TITLE
Feat/handle different geometry column names

### DIFF
--- a/src/scripts/lib/deck-gl/create-geojson-from-data.ts
+++ b/src/scripts/lib/deck-gl/create-geojson-from-data.ts
@@ -28,7 +28,7 @@ export default function createGeojsonFromData(
   const columns = data[0];
   const geometryIndex = columns.indexOf('geometry');
 
-  if (geometryIndex < 0) {
+  if (geometryIndex === -1) {
     return null;
   }
 

--- a/src/scripts/lib/deck-gl/create-geojson-from-data.ts
+++ b/src/scripts/lib/deck-gl/create-geojson-from-data.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import getGeometryColumnName from '../get-geometry-column-name';
+
 /**
  * Create a GeoJSON FeatureCollection from the source data
  */
@@ -26,7 +28,9 @@ export default function createGeojsonFromData(
   };
 
   const columns = data[0];
-  const geometryIndex = columns.indexOf('geometry');
+
+  const geometryColumnName = getGeometryColumnName(data);
+  const geometryIndex = columns.indexOf(geometryColumnName);
 
   if (geometryIndex === -1) {
     return null;
@@ -40,7 +44,8 @@ export default function createGeojsonFromData(
     const geoJsonFeature = getGeoJsonWithProperties(
       row[geometryIndex],
       columns,
-      row
+      row,
+      geometryColumnName
     );
 
     if (
@@ -63,7 +68,8 @@ export default function createGeojsonFromData(
 function getGeoJsonWithProperties(
   geoJsonString: string,
   columns: string[],
-  row: string[]
+  row: string[],
+  geometryColumnName: string
 ): GeoJSON.Feature<any> | null {
   if (!geoJsonString) {
     return null;
@@ -72,7 +78,7 @@ function getGeoJsonWithProperties(
   const geoJson = JSON.parse(geoJsonString) as GeoJSON.Feature<any>;
   geoJson.properties = columns.reduce(
     (all: {[name: string]: any}, current: string, currentIndex: number) => {
-      if (current === 'geometry') {
+      if (current === geometryColumnName) {
         return all;
       }
 

--- a/src/scripts/lib/deck-gl/create-icons-from-data.ts
+++ b/src/scripts/lib/deck-gl/create-icons-from-data.ts
@@ -15,6 +15,7 @@
  */
 
 import {IIcon} from '../../interfaces/icon';
+import getGeometryColumnName from '../get-geometry-column-name';
 
 /**
  * Create an array of marker icons from the source data
@@ -22,7 +23,9 @@ import {IIcon} from '../../interfaces/icon';
 export default function createIconsFromData(data: string[][]): IIcon[] | null {
   const icons: IIcon[] = [];
   const columns = data[0];
-  const geometryIndex = columns.indexOf('geometry');
+
+  const geometryColumnName = getGeometryColumnName(data);
+  const geometryIndex = columns.indexOf(geometryColumnName);
 
   if (geometryIndex === -1) {
     return null;
@@ -33,7 +36,12 @@ export default function createIconsFromData(data: string[][]): IIcon[] | null {
       return;
     }
 
-    const icon = getIconWithProperties(row[geometryIndex], columns, row);
+    const icon = getIconWithProperties(
+      row[geometryIndex],
+      columns,
+      row,
+      geometryColumnName
+    );
 
     if (icon) {
       icons.push(icon);
@@ -49,7 +57,8 @@ export default function createIconsFromData(data: string[][]): IIcon[] | null {
 function getIconWithProperties(
   geoJsonString: string,
   columns: string[],
-  row: string[]
+  row: string[],
+  geometryColumnName: string
 ): IIcon | null {
   if (!geoJsonString) {
     return null;
@@ -65,7 +74,7 @@ function getIconWithProperties(
     position: geoJson.geometry.coordinates,
     properties: columns.reduce(
       (all: {[name: string]: any}, current: string, currentIndex: number) => {
-        if (current === 'geometry') {
+        if (current === geometryColumnName) {
           return all;
         }
 

--- a/src/scripts/lib/get-geometry-column-name.ts
+++ b/src/scripts/lib/get-geometry-column-name.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns the name of the geometry column
+ */
+export default function(data: string[][]): string {
+  const columnNames = data[0].map(columnName => columnName.toLowerCase());
+
+  const anyGeometryColumn = columnNames.find(columnName =>
+    columnName.includes('geometry')
+  );
+
+  if (anyGeometryColumn) {
+    return anyGeometryColumn;
+  }
+
+  const firstRow = data[1];
+  if (firstRow) {
+    const geometryIndex = firstRow.findIndex(cell => {
+      try {
+        const geoJson = JSON.parse(cell);
+        return geoJson && geoJson.type && geoJson.type === 'Feature';
+      } catch (error) {
+        return false;
+      }
+    });
+
+    return columnNames[geometryIndex];
+  }
+
+  return 'geometry';
+}


### PR DESCRIPTION
- Find the column which contains geometry. use 'geometry' column name as fallback. 
- Fix geometry index check in geojson layer

This works now:
![Screenshot 2019-09-30 at 14 36 35](https://user-images.githubusercontent.com/12618489/65892285-4b5d6900-e3a6-11e9-9a5c-d3c7b7368ac3.png)
